### PR TITLE
or quic transport with tcp

### DIFF
--- a/beacon_node/lighthouse_network/src/discovery/enr.rs
+++ b/beacon_node/lighthouse_network/src/discovery/enr.rs
@@ -155,11 +155,11 @@ pub fn create_enr_builder_from_config<T: EnrKey>(
         builder.ip6(*ip);
     }
 
-    if let Some(udp4_port) = config.enr_udp4_port {
+    if let Some(udp4_port) = config.enr_disc4_port {
         builder.udp4(udp4_port);
     }
 
-    if let Some(udp6_port) = config.enr_udp6_port {
+    if let Some(udp6_port) = config.enr_disc6_port {
         builder.udp6(udp6_port);
     }
 

--- a/beacon_node/lighthouse_network/src/listen_addr.rs
+++ b/beacon_node/lighthouse_network/src/listen_addr.rs
@@ -11,7 +11,9 @@ pub struct ListenAddr<Ip> {
     /// The UDP port that discovery will listen on.
     pub disc_port: u16,
     /// The UDP port that QUIC will listen on.
-    pub quic_port: u16,
+    /// NB: Quic port is optional as it's not yet supported with IPV6
+    /// See https://github.com/libp2p/rust-libp2p/issues/4165
+    pub quic_port: Option<u16>,
     /// The TCP port that libp2p will listen on.
     pub tcp_port: u16,
 }
@@ -21,8 +23,20 @@ impl<Ip: Into<IpAddr> + Clone> ListenAddr<Ip> {
         (self.addr.clone().into(), self.disc_port).into()
     }
 
-    pub fn quic_socket_addr(&self) -> SocketAddr {
-        (self.addr.clone().into(), self.quic_port).into()
+    pub fn quic_socket_addr(&self) -> Option<SocketAddr> {
+        let addr: IpAddr = self.addr.clone().into();
+        match addr {
+            IpAddr::V4(ip) => {
+                let addr = (
+                    ip,
+                    self.quic_port
+                        .expect("Quic port should exist on an IPV4 address"),
+                )
+                    .into();
+                Some(addr)
+            }
+            IpAddr::V6(_) => None,
+        }
     }
 
     pub fn libp2p_socket_addr(&self) -> SocketAddr {
@@ -55,15 +69,24 @@ impl ListenAddress {
         }
     }
 
-    /// Returns the TCP addresses.
-    pub fn tcp_addresses(&self) -> impl Iterator<Item = Multiaddr> + '_ {
-        let v4_multiaddr = self
+    /// Returns the Listen addresses.
+    pub fn listen_addresses(&self) -> impl Iterator<Item = Multiaddr> {
+        let v4_tcp_multiaddrs = self
             .v4()
             .map(|v4_addr| Multiaddr::from(v4_addr.addr).with(Protocol::Tcp(v4_addr.tcp_port)));
-        let v6_multiaddr = self
+
+        let v4_quic_multiaddrs = self
+            .v4()
+            .map(|v4_addr| Multiaddr::from(v4_addr.addr).with(Protocol::Tcp(v4_addr.tcp_port)));
+
+        let v6_tcp_multiaddrs = self
             .v6()
             .map(|v6_addr| Multiaddr::from(v6_addr.addr).with(Protocol::Tcp(v6_addr.tcp_port)));
-        v4_multiaddr.into_iter().chain(v6_multiaddr)
+
+        v4_tcp_multiaddrs
+            .into_iter()
+            .chain(v4_quic_multiaddrs)
+            .chain(v6_tcp_multiaddrs)
     }
 
     #[cfg(test)]
@@ -71,7 +94,7 @@ impl ListenAddress {
         ListenAddress::V4(ListenAddr {
             addr: Ipv4Addr::UNSPECIFIED,
             disc_port: unused_port::unused_udp4_port().unwrap(),
-            quic_port: unused_port::unused_udp4_port().unwrap(),
+            quic_port: unused_port::unused_udp4_port().transpose().unwrap(),
             tcp_port: unused_port::unused_tcp4_port().unwrap(),
         })
     }
@@ -81,7 +104,7 @@ impl ListenAddress {
         ListenAddress::V6(ListenAddr {
             addr: Ipv6Addr::UNSPECIFIED,
             disc_port: unused_port::unused_udp6_port().unwrap(),
-            quic_port: unused_port::unused_udp6_port().unwrap(),
+            quic_port: None,
             tcp_port: unused_port::unused_tcp6_port().unwrap(),
         })
     }
@@ -96,13 +119,18 @@ impl slog::KV for ListenAddress {
         if let Some(v4_addr) = self.v4() {
             serializer.emit_arguments("ip4_address", &format_args!("{}", v4_addr.addr))?;
             serializer.emit_u16("disc4_port", v4_addr.disc_port)?;
-            serializer.emit_u16("quic4_port", v4_addr.quic_port)?;
+            serializer.emit_u16(
+                "quic4_port",
+                v4_addr
+                    .quic_port
+                    .expect("Quic port should exist on an IPV4 address"),
+            )?;
             serializer.emit_u16("tcp4_port", v4_addr.tcp_port)?;
         }
         if let Some(v6_addr) = self.v6() {
             serializer.emit_arguments("ip6_address", &format_args!("{}", v6_addr.addr))?;
             serializer.emit_u16("disc6_port", v6_addr.disc_port)?;
-            serializer.emit_u16("quic6_port", v6_addr.quic_port)?;
+            serializer.emit_none("quic6_port")?;
             serializer.emit_u16("tcp6_port", v6_addr.tcp_port)?;
         }
         slog::Result::Ok(())

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -399,7 +399,7 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
         info!(self.log, "Libp2p Starting"; "peer_id" => %enr.peer_id(), "bandwidth_config" => format!("{}-{}", config.network_load, NetworkLoad::from(config.network_load).name));
         debug!(self.log, "Attempting to open listening ports"; config.listen_addrs(), "discovery_enabled" => !config.disable_discovery);
 
-        for listen_multiaddr in config.listen_addrs().tcp_addresses() {
+        for listen_multiaddr in config.listen_addrs().listen_addresses() {
             match self.swarm.listen_on(listen_multiaddr.clone()) {
                 Ok(_) => {
                     let mut log_address = listen_multiaddr;

--- a/beacon_node/lighthouse_network/tests/common.rs
+++ b/beacon_node/lighthouse_network/tests/common.rs
@@ -75,8 +75,8 @@ pub fn build_config(port: u16, mut boot_nodes: Vec<Enr>) -> NetworkConfig {
         .tempdir()
         .unwrap();
 
-    config.set_ipv4_listening_address(std::net::Ipv4Addr::UNSPECIFIED, port, port);
-    config.enr_udp4_port = Some(port);
+    config.set_ipv4_listening_address(std::net::Ipv4Addr::UNSPECIFIED, port, port, port + 1);
+    config.enr_disc4_port = Some(port);
     config.enr_address = (Some(std::net::Ipv4Addr::LOCALHOST), None);
     config.boot_nodes_enr.append(&mut boot_nodes);
     config.network_dir = path.into_path();

--- a/beacon_node/network/src/nat.rs
+++ b/beacon_node/network/src/nat.rs
@@ -29,7 +29,9 @@ impl UPnPConfig {
         config.listen_addrs().v4().map(|v4_addr| UPnPConfig {
             tcp_port: v4_addr.tcp_port,
             disc_port: v4_addr.disc_port,
-            quic_port: v4_addr.quic_port,
+            quic_port: v4_addr
+                .quic_port
+                .expect("Quic port should exist on an IPV4 address"),
             disable_discovery: config.disable_discovery,
             disable_quic_support: config.disable_quic_support,
         })

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -89,7 +89,8 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
             Arg::with_name("port")
                 .long("port")
                 .value_name("PORT")
-                .help("The TCP/UDP ports to listen on. There are two UDP ports. The discovery UDP port will be set to this value and the Quic UDP port will be set to his value + 1. The discovery port can be modified by the \
+                .help("The TCP/UDP ports to listen on. There are two UDP ports. \
+                      The discovery UDP port will be set to this value and the Quic UDP port will be set to this value + 1. The discovery port can be modified by the \
                       --discovery-port flag and the quic port can be modified by the --quic-port flag. If listening over both IPv4 and IPv6 the --port flag \
                       will apply to the IPv4 address and --port6 to the IPv6 address.")
                 .default_value("9000")
@@ -246,7 +247,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
             Arg::with_name("disable-discovery")
                 .long("disable-discovery")
                 .help("Disables the discv5 discovery protocol. The node will not search for new peers or participate in the discovery protocol.")
-                .takes_value(false),
+                .takes_value(false)
                 .hidden(true)
         )
         .arg(

--- a/boot_node/src/config.rs
+++ b/boot_node/src/config.rs
@@ -57,20 +57,20 @@ impl<T: EthSpec> BootNodeConfig<T> {
 
         set_network_config(&mut network_config, matches, &data_dir, &logger)?;
 
-        // Set the Enr UDP ports to the listening ports if not present.
+        // Set the Enr Discovery ports to the listening ports if not present.
         if let Some(listening_addr_v4) = network_config.listen_addrs().v4() {
-            network_config.enr_udp4_port = Some(
+            network_config.enr_disc4_port = Some(
                 network_config
-                    .enr_udp4_port
-                    .unwrap_or(listening_addr_v4.udp_port),
+                    .enr_disc4_port
+                    .unwrap_or(listening_addr_v4.disc_port),
             )
         };
 
         if let Some(listening_addr_v6) = network_config.listen_addrs().v6() {
-            network_config.enr_udp6_port = Some(
+            network_config.enr_disc6_port = Some(
                 network_config
-                    .enr_udp6_port
-                    .unwrap_or(listening_addr_v6.udp_port),
+                    .enr_disc6_port
+                    .unwrap_or(listening_addr_v6.disc_port),
             )
         };
 

--- a/lcli/src/generate_bootnode_enr.rs
+++ b/lcli/src/generate_bootnode_enr.rs
@@ -27,7 +27,7 @@ pub fn run<T: EthSpec>(matches: &ArgMatches) -> Result<(), String> {
 
     let mut config = NetworkConfig::default();
     config.enr_address = (Some(ip), None);
-    config.enr_udp4_port = Some(udp_port);
+    config.enr_disc4_port = Some(udp_port);
     config.enr_tcp6_port = Some(tcp_port);
 
     let secp256k1_keypair = secp256k1::Keypair::generate();

--- a/testing/node_test_rig/src/lib.rs
+++ b/testing/node_test_rig/src/lib.rs
@@ -98,7 +98,7 @@ pub fn testing_client_config() -> ClientConfig {
     // Setting ports to `0` means that the OS will choose some available port.
     client_config
         .network
-        .set_ipv4_listening_address(std::net::Ipv4Addr::UNSPECIFIED, 0, 0);
+        .set_ipv4_listening_address(std::net::Ipv4Addr::UNSPECIFIED, 0, 0, 0);
     client_config.network.upnp_enabled = false;
     client_config.http_api.enabled = true;
     client_config.http_api.listen_port = 0;

--- a/testing/simulator/src/local_network.rs
+++ b/testing/simulator/src/local_network.rs
@@ -14,6 +14,7 @@ use std::{sync::Arc, time::Duration};
 use types::{Epoch, EthSpec};
 
 const BOOTNODE_PORT: u16 = 42424;
+const QUIC_PORT: u16 = BOOTNODE_PORT + 1;
 pub const INVALID_ADDRESS: &str = "http://127.0.0.1:42423";
 
 pub const EXECUTION_PORT: u16 = 4000;
@@ -63,8 +64,9 @@ impl<E: EthSpec> LocalNetwork<E> {
             std::net::Ipv4Addr::UNSPECIFIED,
             BOOTNODE_PORT,
             BOOTNODE_PORT,
+            QUIC_PORT,
         );
-        beacon_config.network.enr_udp4_port = Some(BOOTNODE_PORT);
+        beacon_config.network.enr_disc4_port = Some(BOOTNODE_PORT);
         beacon_config.network.enr_tcp4_port = Some(BOOTNODE_PORT);
         beacon_config.network.discv5_config.table_filter = |_| true;
 
@@ -154,8 +156,9 @@ impl<E: EthSpec> LocalNetwork<E> {
                 std::net::Ipv4Addr::UNSPECIFIED,
                 BOOTNODE_PORT + count,
                 BOOTNODE_PORT + count,
+                BOOTNODE_PORT + count + 1,
             );
-            beacon_config.network.enr_udp4_port = Some(BOOTNODE_PORT + count);
+            beacon_config.network.enr_disc4_port = Some(BOOTNODE_PORT + count);
             beacon_config.network.enr_tcp4_port = Some(BOOTNODE_PORT + count);
             beacon_config.network.discv5_config.table_filter = |_| true;
             beacon_config.network.proposer_only = is_proposer;


### PR DESCRIPTION
by `map`ing quic's `Connection` on the `Either::Right` into a `StreamMuxerBox`.

**Note**:
Haven't tested if the IPv6 support works after https://github.com/libp2p/rust-libp2p/pull/3454, left a [comment there](https://github.com/libp2p/rust-libp2p/issues/4165). If Max hasn't tried I can take a stab on it.